### PR TITLE
feat: add refresh layer message

### DIFF
--- a/addons/embedit/components/Embedit.vue
+++ b/addons/embedit/components/Embedit.vue
@@ -83,7 +83,7 @@ export default {
         this.unregisterListener();
     },
     methods: {
-        ...mapActions('Maps', [ 'addNewLayerIfNotExists', 'addInteraction', 'removeInteraction', 'zoomToExtent', 'getLayerById' ]),
+        ...mapActions('Maps', [ 'addNewLayerIfNotExists', 'addInteraction', 'removeInteraction', 'zoomToExtent' ]),
         ...mapActions('Modules/Embedit', Object.keys(actions)),
         ...mapActions('Alerting', [ 'addSingleAlert' ]),
         addFeatureTo (itemId, columnId, geom, extraProperties, layer) {
@@ -602,7 +602,7 @@ export default {
         refreshLayer (id) {
             const layer = this.getLayerById(id);
             if (layer) {
-                layer.getSource().refresh();
+                layer.getSource()?.refresh();
             }
         }
     }

--- a/addons/embedit/components/Embedit.vue
+++ b/addons/embedit/components/Embedit.vue
@@ -83,7 +83,7 @@ export default {
         this.unregisterListener();
     },
     methods: {
-        ...mapActions('Maps', [ 'addNewLayerIfNotExists', 'addInteraction', 'removeInteraction', 'zoomToExtent' ]),
+        ...mapActions('Maps', [ 'addNewLayerIfNotExists', 'addInteraction', 'removeInteraction', 'zoomToExtent', 'getLayerById' ]),
         ...mapActions('Modules/Embedit', Object.keys(actions)),
         ...mapActions('Alerting', [ 'addSingleAlert' ]),
         addFeatureTo (itemId, columnId, geom, extraProperties, layer) {
@@ -569,6 +569,9 @@ export default {
                 case RECEIVE_EVENTS.disableItemSelection:
                     this.disableItemSelection();
                     break;
+                case RECEIVE_EVENTS.refreshLayer:
+                    this.refreshLayer(evtPayload);
+                    break;
                 default:
                     break;
             }
@@ -595,6 +598,12 @@ export default {
         },
         stopInteraction (id) {
             this.getInteractionById(id).setActive(false);
+        },
+        refreshLayer (id) {
+            const layer = this.getLayerById(id);
+            if (layer) {
+                layer.getSource().refresh();
+            }
         }
     }
 };

--- a/addons/embedit/constants/events.js
+++ b/addons/embedit/constants/events.js
@@ -61,7 +61,11 @@ export const RECEIVE_EVENTS = {
         /**
          * Disables item selection on the map.
          */
-        disableItemSelection: 'embedit/disableItemSelection'
+        disableItemSelection: 'embedit/disableItemSelection',
+        /**
+         * Refreshes layer source of a given layer id.
+         */
+        refreshLayer: 'embedit/refreshLayer'
     },
 
     // Events that will be sent by the embedit addon


### PR DESCRIPTION
# Feature
Listen to postmessage `refreshLayer` and calls the respective refresh function for the ol layer source.  
Requires https://github.com/formcapture/form-backend/pull/275.

<img width="1053" height="754" alt="Peek 2026-04-23 10-39" src="https://github.com/user-attachments/assets/90346fef-da0a-4899-b7a8-0dbbc4c76ad7" />
